### PR TITLE
Add support for City data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Useful extras based on the ``django.contrib.gis.geoip2`` module, using
 the `MaxMind GeoIP2 Lite <http://dev.maxmind.com/geoip/geoip2/geolite2/>`_ database.
 
 The first feature in this package is a Django middleware class that can
-be used to add country level information to inbound requests.
+be used to add city, country level information to inbound requests.
 
 Requirements
 ============
@@ -53,41 +53,51 @@ the default ``GEOIP_PATH`` - this is the default Django GeoIP2 behaviour:
     # settings.py
     GEOIP_PATH = os.path.dirname(__file__)
 
-NB Loading this package does *not* install the `MaxMind database <http://dev.maxmind.com/geoip/geoip2/geolite2/>`_
-. That is
-your responsibility. The Country database is 2.7MB, and could be added
-to most project comfortably, but it is updated regularly, and keeping that
-up-to-date is out of scope for this project.
+NB Loading this package does *not* install the `MaxMind database <http://dev.maxmind.com/geoip/geoip2/geolite2/>`_.
+That is your responsibility. The Country database is 2.7MB, and could be added to most project comfortably, but it is updated regularly, and keeping that up-to-date is out of scope for this project. The City database is 27MB, and is probably not suitable for adding to source control. There are various solutions out on the web for pulling in the City database as part of a CD process. 
 
 Usage
 =====
 
-Once the middleware is added, you will be able to access Country level
+Once the middleware is added, you will be able to access City and / or Country level
 information on the request object:
 
 .. code:: python
 
-    >>> request.country
-    {
-        'ip_address': '1.2.3.4',
-        'country_code': 'GB',
-        'country_name': 'United Kingdom'
-    }
+    >>> request.geo_data.ip_address
+    '1.2.3.4'
+    >>> request.geo_data.city
+    'Beverley Hills'
+    >>> request.geo_data.postal_code
+    '90210'
+    >>> request.geo_data.region
+    'California'
+    >>> request.geo_data.country_code
+    'US'
+    >>> request.geo_data.country_name
+    'United States'
+    >>> request.geo_data.latitude
+    '34.0736'
+    >>> request.geo_data.longitude
+    '118.4004'
 
-If the IP address cannot be found (e.g. localhost), then a default 'unknown'
-country dict is used.
+Missing / incomplete data will be None.
+
+If the IP address cannot be found (e.g. '127.0.0.1'), then a default 'unknown'
+country is used, with a code of 'XX'. The GeoData class has a `is_unkown` property to make it easier to use:
 
 .. code:: python
 
-    >>> request.country
-    {
-        'ip_address': '127.0.0.1',
-        'country_code': 'XX',
-        'country_name': 'unknown'
-    }
+    >>> geo.ip_address
+    '127.0.0.1'
+    >>> geo.country_code
+    'XX'
+    >>> geo.country_name
+    'unknown'
+    >>> geo.is_unknown
+    True
 
-This prevents the middleware from re-requesting the address on each request -
-it effectively marks the IP as a bad address.
+This prevents the middleware from re-requesting the address on each request - it effectively marks the IP as a bad address.
 
 Tests
 =====

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ information on the request object:
 Missing / incomplete data will be None.
 
 If the IP address cannot be found (e.g. '127.0.0.1'), then a default 'unknown'
-country is used, with a code of 'XX'. The GeoData class has a `is_unkown` property to make it easier to use:
+country is used, with a code of 'XX':
 
 .. code:: python
 

--- a/geoip2_extras/middleware.py
+++ b/geoip2_extras/middleware.py
@@ -26,8 +26,9 @@ class GeoData(object):
         self.postal_code = geoip_data.get('postal_code')
         self.region = geoip_data.get('region')
 
+    @property
     def is_unknown(self):
-        return self.county_code == GeoData.UNKNOWN_COUNTRY_CODE
+        return self.country_code == GeoData.UNKNOWN_COUNTRY_CODE
 
     @classmethod
     def unknown_country(cls, ip_address):

--- a/geoip2_extras/middleware.py
+++ b/geoip2_extras/middleware.py
@@ -117,14 +117,17 @@ class GeoIP2Middleware(object):
         """
         Return GeoData object containing info from GeoIP2.
 
-        This method does the actual lookup. It will use the City database if
-        one exists, else it will default to the Country database. If neither
-        exist the the middleware _should_ be disabled in the __init__ method.
+        This method does the actual lookup, using the geoip2 method specified.
 
-        If the address cannot be found (e.g. localhost) then it will still
-        return an object that can be stashed in the session to prevent repeated
-        invalid lookups. If the lookup raises any other exception it returns
-        None, so that future requests _will_ repeat the lookup.
+        Args:
+            ip_address:  the IP address to look up, as a string.
+            geo_func: a function, must be GeoIP2.city or GeoIP2.country,
+                used to do the IP lookup.
+                
+        Returns a GeoData object. If the address cannot be found (e.g. localhost)
+            then it will still return an object that can be stashed in the session
+            to prevent repeated invalid lookups. If the lookup raises any other
+            exception it returns None, so that future requests _will_ repeat the lookup.
 
         """
         try:

--- a/geoip2_extras/middleware.py
+++ b/geoip2_extras/middleware.py
@@ -8,6 +8,37 @@ from django.core.exceptions import MiddlewareNotUsed
 logger = logging.getLogger(__name__)
 
 
+class GeoData(object):
+
+    """Container for GeoIP2 return data."""
+
+    UNKNOWN_COUNTRY_CODE = 'XX'
+    UNKNOWN_COUNTRY_NAME = 'unknown'
+
+    def __init__(self, ip_address, **geoip_data):
+        self.ip_address = ip_address
+        self.city = geoip_data.get('city')
+        self.country_code = geoip_data.get('country_code')
+        self.country_name = geoip_data.get('country_name')
+        self.dma_code = geoip_data.get('dma_code')
+        self.latitude = geoip_data.get('latitude')
+        self.longitude = geoip_data.get('longitude')
+        self.postal_code = geoip_data.get('postal_code')
+        self.region = geoip_data.get('region')
+
+    def is_unknown(self):
+        return self.county_code == GeoData.UNKNOWN_COUNTRY_CODE
+
+    @classmethod
+    def unknown_country(cls, ip_address):
+        """Return a new GeoData object representing an unknown country."""
+        return GeoData(
+            ip_address=ip_address,
+            country_code=GeoData.UNKNOWN_COUNTRY_CODE,
+            country_name=GeoData.UNKNOWN_COUNTRY_NAME
+        )
+
+
 class GeoIP2Middleware(object):
 
     """
@@ -23,8 +54,6 @@ class GeoIP2Middleware(object):
 
     """
     SESSION_KEY = 'geoip2'
-    UNKNOWN_COUNTRY_CODE = 'XX'
-    UNKNOWN_COUNTRY_NAME = 'unknown'
 
     def __init__(self, get_response):
         """Check settings to see if middleware is enabled, and try to init GeoIP2."""
@@ -32,7 +61,8 @@ class GeoIP2Middleware(object):
             self.geoip2 = GeoIP2()
         except GeoIP2Exception:
             raise MiddlewareNotUsed("Error loading GeoIP2 data")
-        self.get_response = get_response
+        else:
+            self.get_response = get_response
 
     def __call__(self, request):
         """
@@ -46,10 +76,10 @@ class GeoIP2Middleware(object):
         ip_address = self.remote_addr(request)
         data = request.session.get(GeoIP2Middleware.SESSION_KEY)
         if data is None:
-            data = self.country(ip_address)
-        elif data['ip_address'] != ip_address:
-            data = self.country(ip_address)
-        request.session[GeoIP2Middleware.SESSION_KEY] = request.country = data
+            data = self.get_geo_data(ip_address)
+        elif data.ip_address != ip_address:
+            data = self.get_geo_data(ip_address)
+        request.session[GeoIP2Middleware.SESSION_KEY] = request.geo_data = data
         return self.get_response(request)
 
     def remote_addr(self, request):
@@ -70,28 +100,38 @@ class GeoIP2Middleware(object):
         # http://stackoverflow.com/a/37061471/45698
         return header.split(',')[-1]
 
-    def country(self, ip_address):
-        """
-        Return dict containing country info from GeoIP2.
+    def get_geo_data(self, ip_address):
+        """Return City and / or Country data for an IP address."""
+        return self.city(ip_address) if self.geoip2._city else self.country(ip_address)
 
-        This method does the actual lookup. If the address cannot be found (
-        e.g. localhost) then it will still return a dict that can be stashed
-        in the session to prevent repeated invalid lookups. If the lookup raises
-        any other exception it returns None, so that future requests _will_
-        repeat the lookup.
+    def country(self, ip_address):
+        """Return GeoIP2 Country database data."""
+        return self._geoip2(ip_address, self.geoip2.country)
+
+    def city(self, ip_address):
+        """Return GeoIP2 City database data."""
+        return self._geoip2(ip_address, self.geoip2.city)
+
+    def _geoip2(self, ip_address, geo_func):
+        """
+        Return GeoData object containing info from GeoIP2.
+
+        This method does the actual lookup. It will use the City database if
+        one exists, else it will default to the Country database. If neither
+        exist the the middleware _should_ be disabled in the __init__ method.
+
+        If the address cannot be found (e.g. localhost) then it will still
+        return an object that can be stashed in the session to prevent repeated
+        invalid lookups. If the lookup raises any other exception it returns
+        None, so that future requests _will_ repeat the lookup.
 
         """
         try:
-            country = self.geoip2.country(ip_address)
-            country['ip_address'] = ip_address
-            return country
+            return GeoData(ip_address, **geo_func(ip_address))
         except AddressNotFoundError:
             logger.debug("IP address not found in MaxMind database: %s", ip_address)
-            return {
-                'ip_address': ip_address,
-                'country_code': GeoIP2Middleware.UNKNOWN_COUNTRY_CODE,
-                'country_name': GeoIP2Middleware.UNKNOWN_COUNTRY_NAME
-            }
+            return GeoData.unknown_country(ip_address)
+        except GeoIP2Exception:
+            logger.exception("GeoIP2 exception raised for %s", ip_address)
         except Exception:
-            logger.exception("Error raised looking up remote_addr: %s", ip_address)
-            return None
+            logger.exception("Error raised looking up geoip2 data for %s", ip_address)

--- a/geoip2_extras/tests.py
+++ b/geoip2_extras/tests.py
@@ -12,6 +12,15 @@ from .middleware import (
 )
 
 
+class GeoDataTests(TestCase):
+
+    def test_is_unknown(self):
+        geo = GeoData('8.8.8.8')
+        self.assertFalse(geo.is_unknown)
+        geo.country_code = GeoData.UNKNOWN_COUNTRY_CODE
+        self.assertTrue(geo.is_unknown)
+
+
 @override_settings(GEOIP2_MIDDLEWARE_ENABLED=True)
 class GeoIP2MiddlewareTests(TestCase):
 
@@ -25,14 +34,22 @@ class GeoIP2MiddlewareTests(TestCase):
             'country_code': 'GB',
             'country_name': 'United Kingdom'
         }
-        self.test_geo_data = GeoData(self.test_ip, **self.test_country)
+        self.test_city = {
+            'city': 'Los Angeles',
+            'country_code': 'US',
+            'country_name': 'United States',
+            'dma_code': None,
+            'latitude': 37.751,
+            'longitude': -97.822,
+            'postal_code': 90210,
+            'region': 'CA'
+        }
+         # self.test_geo_data = GeoData(self.test_ip, **self.test_country)
 
     def test_remote_addr(self):
         request = mock.Mock(META={})
         self.assertEqual(self.middleware.remote_addr(request), '0.0.0.0')
-        request.META = {
-            'REMOTE_ADDR': '1.2.3.4'
-        }
+        request.META['REMOTE_ADDR'] = '1.2.3.4'
         self.assertEqual(self.middleware.remote_addr(request), '1.2.3.4')
         request.META['HTTP_X_FORWARDED_FOR'] = '8.8.8.8'
         self.assertEqual(self.middleware.remote_addr(request), '8.8.8.8')
@@ -43,29 +60,44 @@ class GeoIP2MiddlewareTests(TestCase):
         request.META['REMOTE_ADDR'] = None
         self.assertEqual(self.middleware.remote_addr(request), '0.0.0.0')
 
-    @mock.patch.object(GeoIP2, 'country')
-    def test_country(self, mock_country):
-        mock_country.return_value = self.test_country
-        data = self.middleware.country(self.test_ip)
-        self.assertEqual(data.ip_address, '8.8.8.8')
-        self.assertEqual(data.country_code, 'GB')
-        self.assertEqual(data.country_name, 'United Kingdom')
+    @mock.patch.object(GeoIP2Middleware, '_geoip2')
+    def test_get_geo_data(self, mock__geoip2):
+        """Check that city / country routing works."""
+        self.middleware.geoip2 = mock.Mock(_city=True)
+        self.middleware.get_geo_data(self.test_ip)
+        mock__geoip2.assert_called_with(self.test_ip, self.middleware.geoip2.city)
 
-        mock_country.side_effect = AddressNotFoundError()
-        data = self.middleware.country(self.test_ip)
-        self.assertEqual(data.ip_address, '8.8.8.8')
-        self.assertEqual(data.country_code, GeoData.UNKNOWN_COUNTRY_CODE)
-        self.assertEqual(data.country_name, GeoData.UNKNOWN_COUNTRY_NAME)
+        self.middleware.geoip2 = mock.Mock(_city=None)
+        self.middleware.get_geo_data(self.test_ip)
+        mock__geoip2.assert_called_with(self.test_ip, self.middleware.geoip2.country)
 
-        mock_country.side_effect = Exception()
-        data = self.middleware.country(self.test_ip)
-        self.assertIsNone(data)
+    @mock.patch.object(GeoIP2, 'city')
+    def test__geoip2(self, mock_city):
+        mock_city.return_value = self.test_city
+        data = self.middleware._geoip2(self.test_ip, mock_city)
+        self.assertEqual(data.ip_address, '8.8.8.8')
+        self.assertEqual(data.city, 'Los Angeles')
+        self.assertEqual(data.country_code, 'US')
+        self.assertEqual(data.country_name, 'United States')
+        self.assertEqual(data.dma_code, None)
+        self.assertEqual(data.latitude, 37.751)
+        self.assertEqual(data.longitude, -97.822)
+        self.assertEqual(data.postal_code, 90210)
+        self.assertEqual(data.region, 'CA')
+        mock_city.side_effect = AddressNotFoundError()
+        data = self.middleware.city(self.test_ip)
+        self.assertTrue(data.is_unknown)
+
+        mock_city.side_effect = GeoIP2Exception()
+        self.assertIsNone(self.middleware.city(self.test_ip))
+
+        mock_city.side_effect = Exception()
+        self.assertIsNone(self.middleware.city(self.test_ip))
 
     @mock.patch.object(GeoIP2Middleware, 'country')
     def test_middleware_call(self, mock_country):
         middleware = GeoIP2Middleware(lambda r: None)
-        request = mock.Mock()
-        request.META = {'REMOTE_ADDR': self.test_ip}
+        request = mock.Mock(META={'REMOTE_ADDR': self.test_ip})
 
         # test: clean session
         request.session = {}
@@ -76,7 +108,7 @@ class GeoIP2MiddlewareTests(TestCase):
 
         # test: object in session does not match current IP
         mock_country.reset_mock()
-        request.session[GeoIP2Middleware.SESSION_KEY] = self.test_geo_data
+        request.session[GeoIP2Middleware.SESSION_KEY] = GeoData(ip_address=self.test_ip, **self.test_city)
         request.session[GeoIP2Middleware.SESSION_KEY].ip_address = '1.2.3.4'
         middleware(request)
         mock_country.assert_called_with(self.test_ip)
@@ -85,7 +117,7 @@ class GeoIP2MiddlewareTests(TestCase):
 
         # test: session object is up-to-date
         mock_country.reset_mock()
-        request.session[GeoIP2Middleware.SESSION_KEY] = self.test_geo_data
+        request.session[GeoIP2Middleware.SESSION_KEY] = GeoData(ip_address=self.test_ip, **self.test_city)
         request.session[GeoIP2Middleware.SESSION_KEY].ip_address = self.test_ip
         middleware(request)
         mock_country.assert_not_called()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ chdir(path.normpath(path.join(path.abspath(__file__), pardir)))
 
 setup(
     name="django-geoip2-extras",
-    version="0.1.2",
+    version="0.2",
     packages=find_packages(),
     install_requires=[
         'Django>=1.10',


### PR DESCRIPTION
Support for the MaxMind City database, in addition to the Country database.

This is a breaking change - instead of adding `country` to the request object, this now adds a new `GeoData` object as the `request.geo_data` attribute. This contains city data if the city database is available, else just the country data.
