### PR TITLE
get_response should be optional in Django 1.10+

### DIFF
--- a/geoip2_extras/middleware.py
+++ b/geoip2_extras/middleware.py
@@ -56,7 +56,7 @@ class GeoIP2Middleware(object):
     """
     SESSION_KEY = 'geoip2'
 
-    def __init__(self, get_response):
+    def __init__(self, get_response=None):
         """Check settings to see if middleware is enabled, and try to init GeoIP2."""
         try:
             self.geoip2 = GeoIP2()


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-middleware