### PR TITLE
Fix issue #4, remove python2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language:
     python
 
 python:
-  - "2.7"
   - "3.6"
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,12 @@
 Django GeoIP2 Extras
 --------------------
 
+Python2/3
+---------
+
+**The master branch of this project is now Python3 only. Python2 support is
+restricted to the python2 branch.**
+
 Useful extras based on the ``django.contrib.gis.geoip2`` module, using
 the `MaxMind GeoIP2 Lite <http://dev.maxmind.com/geoip/geoip2/geolite2/>`_ database.
 
@@ -54,7 +60,7 @@ the default ``GEOIP_PATH`` - this is the default Django GeoIP2 behaviour:
     GEOIP_PATH = os.path.dirname(__file__)
 
 NB Loading this package does *not* install the `MaxMind database <http://dev.maxmind.com/geoip/geoip2/geolite2/>`_.
-That is your responsibility. The Country database is 2.7MB, and could be added to most project comfortably, but it is updated regularly, and keeping that up-to-date is out of scope for this project. The City database is 27MB, and is probably not suitable for adding to source control. There are various solutions out on the web for pulling in the City database as part of a CD process. 
+That is your responsibility. The Country database is 2.7MB, and could be added to most project comfortably, but it is updated regularly, and keeping that up-to-date is out of scope for this project. The City database is 27MB, and is probably not suitable for adding to source control. There are various solutions out on the web for pulling in the City database as part of a CD process.
 
 Usage
 =====

--- a/geoip2_extras/apps.py
+++ b/geoip2_extras/apps.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.apps import AppConfig
 
 

--- a/geoip2_extras/middleware.py
+++ b/geoip2_extras/middleware.py
@@ -60,7 +60,7 @@ class GeoIP2Middleware(object):
         """Check settings to see if middleware is enabled, and try to init GeoIP2."""
         try:
             self.geoip2 = GeoIP2()
-        except GeoIP2Exception:
+        except Exception:
             raise MiddlewareNotUsed("Error loading GeoIP2 data")
         else:
             self.get_response = get_response
@@ -123,7 +123,7 @@ class GeoIP2Middleware(object):
             ip_address:  the IP address to look up, as a string.
             geo_func: a function, must be GeoIP2.city or GeoIP2.country,
                 used to do the IP lookup.
-                
+
         Returns a GeoData object. If the address cannot be found (e.g. localhost)
             then it will still return an object that can be stashed in the session
             to prevent repeated invalid lookups. If the lookup raises any other

--- a/geoip2_extras/tests.py
+++ b/geoip2_extras/tests.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 
 from django.contrib.gis.geoip2 import GeoIP2, GeoIP2Exception
 from django.core.exceptions import MiddlewareNotUsed
@@ -44,7 +43,6 @@ class GeoIP2MiddlewareTests(TestCase):
             'postal_code': 90210,
             'region': 'CA'
         }
-         # self.test_geo_data = GeoData(self.test_ip, **self.test_country)
 
     def test_remote_addr(self):
         request = mock.Mock(META={})
@@ -108,7 +106,7 @@ class GeoIP2MiddlewareTests(TestCase):
 
         # test: object in session does not match current IP
         mock_country.reset_mock()
-        request.session[GeoIP2Middleware.SESSION_KEY] = GeoData(ip_address=self.test_ip, **self.test_city)
+        request.session[GeoIP2Middleware.SESSION_KEY] = GeoData(ip_address=self.test_ip, **self.test_city)  # noqa
         request.session[GeoIP2Middleware.SESSION_KEY].ip_address = '1.2.3.4'
         middleware(request)
         mock_country.assert_called_with(self.test_ip)
@@ -117,7 +115,7 @@ class GeoIP2MiddlewareTests(TestCase):
 
         # test: session object is up-to-date
         mock_country.reset_mock()
-        request.session[GeoIP2Middleware.SESSION_KEY] = GeoData(ip_address=self.test_ip, **self.test_city)
+        request.session[GeoIP2Middleware.SESSION_KEY] = GeoData(ip_address=self.test_ip, **self.test_city)  # noqa
         request.session[GeoIP2Middleware.SESSION_KEY].ip_address = self.test_ip
         middleware(request)
         mock_country.assert_not_called()
@@ -126,8 +124,8 @@ class GeoIP2MiddlewareTests(TestCase):
     def test_init(self, mock_geo2):
         middleware = GeoIP2Middleware(GeoIP2MiddlewareTests.get_response)
         self.assertEqual(middleware.get_response, GeoIP2MiddlewareTests.get_response)
-        # test: GeoIP2 can't be initialised
-        mock_geo2.side_effect = GeoIP2Exception()
+        # Issue #4: database missing, raises AttributeError
+        mock_geo2.side_effect = Exception()
         self.assertRaises(
             MiddlewareNotUsed,
             GeoIP2Middleware,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ chdir(path.normpath(path.join(path.abspath(__file__), pardir)))
 
 setup(
     name="django-geoip2-extras",
-    version="0.2",
+    version="1.0",
     packages=find_packages(),
     install_requires=[
         'Django>=1.10',
@@ -30,11 +30,11 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,15 @@
 [tox]
-envlist = py{27,36}-django{110,111}
+envlist = py36-django{110,111,20}
 
 [testenv]
 commands =
     coverage erase
     coverage run --branch --include=geoip2_extras* --omit=*migrations* manage.py test geoip2_extras --verbosity=2
     coverage report -m
+    coverage html
 
 deps =
     coverage==4.3
-    mock==2.0
     django110: Django==1.10
     django111: Django==1.11
+    django20: Django==2.0


### PR DESCRIPTION
Fixes the issue whereby if the database file does not exists GeoIP2 raises an `AttributeError`, and not a `GeoIP2Exception` as expected.

At the same time I have deprecated Python2. This project is now Python3 only.
