### PR TITLE
Allow users to re-use an existing Django cache configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,35 +4,50 @@ max-complexity = 8
 # http://flake8.pycqa.org/en/2.5.5/warnings.html#warning-error-codes
 ignore =
   # pydocstyle - docstring conventions (PEP257)
-  D100	# Missing docstring in public module
-  D101	# Missing docstring in public class
-  D102	# Missing docstring in public method
-  D103	# Missing docstring in public function
-  D104	# Missing docstring in public package
-  D105	# Missing docstring in magic method
-  D106	# Missing docstring in public nested class
-  D107	# Missing docstring in __init__
-  D412  # No blank lines allowed between a section header and its content
+  # Missing docstring in public module
+  D100,
+  # Missing docstring in public class
+  D101,
+  # Missing docstring in public method
+  D102,
+  # Missing docstring in public function
+  D103,
+  # Missing docstring in public package
+  D104,
+  # Missing docstring in magic method
+  D105,
+  # Missing docstring in public nested class
+  D106,
+  # Missing docstring in __init__
+  D107,
+  # No blank lines allowed between a section header and its content
+  D412,
   # pycodestyle - style checker (PEP8)
-  W503  # line break before binary operator
+  # line break before binary operator
+  W503
   # the following are ignored in CI using --extend-ignore option:
-  ; D205  # [pydocstyle] 1 blank line required between summary line and description
-  ; D400  # [pydocstyle] First line should end with a period
-  ; D401  # [pydocstyle] First line should be in imperative mood
-  ; S308  # [bandit] Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.
-  ; S703  # [bandit] Potential XSS on mark_safe function.
+  # [pydocstyle] 1 blank line required between summary line and description
+  D205,
+  # [pydocstyle] First line should end with a period
+  D400,
+  # [pydocstyle] First line should be in imperative mood
+  D401,
+  # [bandit] Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.
+  S308,
+  # [bandit] Potential XSS on mark_safe function.
+  S703
 
 per-file-ignores =
-  ; D205 - 1 blank line required between summary line and description
-  ; D400 - First line should end with a period
-  ; D401 - First line should be in imperative mood
-  ; S101 - use of assert
-  ; S106 - hard-coded password
-  ; E501 - line-length
-  ; E731 - assigning a lambda to a variable
+  # D205 - 1 blank line required between summary line and description
+  # D400 - First line should end with a period
+  # D401 - First line should be in imperative mood
+  # S101 - use of assert
+  # S106 - hard-coded password
+  # E501 - line-length
+  # E731 - assigning a lambda to a variable
   *tests/*:D205,D400,D401,S101,S106,E501,E731
   */migrations/*:E501
-  ; F403 - unable to detect undefined names
-  ; F405 - may be undefined, or defined from star imports
+  # F403 - unable to detect undefined names
+  # F405 - may be undefined, or defined from star imports
   */settings.py:F403,F405
   */settings/*:F403,F405

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
-## v3.0 [unreleased]
+## v4.0 [Breaking Changes]
+
+The library now asks for which Django cache configuraiton to use rather
+than requiring it's own entry in Django's CACHES setting. This means you
+can take advantage of an existing cache and any features you have set up
+with it such as connection pooling.
+
+If you wish to continue as you were before without modifying your Django
+Cache configuration, then set the new setting to:
+
+```
+GEOIP2_EXTRAS_CACHE_NAME = "geoip2-extras"
+```
+
+As you would already have the `geoip2-extras` cache configuration set up
+from previously using this library.
+
+## v3.0 [Breaking Changes]
 
 * Add support for Python 3.11
 * Drop support for Python 3.7

--- a/README.md
+++ b/README.md
@@ -5,15 +5,14 @@ the [MaxMind GeoIP2 Lite](http://dev.maxmind.com/geoip/geoip2/geolite2/) databas
 
 The first feature in this package is a Django middleware class that can
 be used to add city, country level information to inbound requests.
+
 ### Version support
 
 The current version of the this app support **Python 3.8+** and **Django 3.2+**
 
 ## Requirements
 
-This package requires Django 2.2 or above, and Python 3.7 or above.
-
-This package wraps the existing Django functionality, and as a result
+1) This package wraps the existing Django functionality, and as a result
 relies on the same underlying requirements:
 
     In order to perform IP-based geolocation, the GeoIP2 object
@@ -22,8 +21,12 @@ relies on the same underlying requirements:
     GeoLite2-Country.mmdb.gz and GeoLite2-City.mmdb.gz files and unzip
     them in a directory corresponding to the GEOIP_PATH setting.
 
-NB The MaxMind database is not included with this package. It is your
+NB: The MaxMind database is not included with this package. It is your
 responsiblity to download this and include it as part of your project.
+
+2) This package requires the usage of a Django cache configuration to
+maintain adaquate performance.
+
 
 ## Installation
 
@@ -52,22 +55,33 @@ default `GEOIP_PATH` - this is the default Django GeoIP2 behaviour:
 GEOIP_PATH = os.path.dirname(__file__)
 ```
 
-You must also configure a cache called `geoip2-extras`:
+You must also configure a cache to use  via `GEOIP2_EXTRAS_CACHE_NAME`.
+The value should match the name of the Django cache configuration you
+wish to use for caching.
 
 ```python
-# settings
+# settings.py
+
+# Django cache configuration setting
 CACHES = {
     "default": { ... },
-    "geoip2-extras": { ... },
+    "some-other-cache": { ... },  # <-- it would use this one.
     ...
 }
+
+# Set this to specific configuration name from CACHES
+GEOIP2_EXTRAS_CACHE_NAME = "some-other-cache"
 ```
 
 Tip: see `/demo/settings.py` for a full working example.
 
 ### Settings
 
-The following settings can be overridden in `django.conf.settings`.
+The following settings can be overridden via your Django settings:
+
+* `GEOIP2_EXTRAS_CACHE_NAME`
+
+The Django cache configuration to use for cacheing.
 
 * `GEOIP2_EXTRAS_CACHE_TIMEOUT`
 

--- a/demo/settings.py
+++ b/demo/settings.py
@@ -36,7 +36,6 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     },
-    # required in order for IP addresses to be cached
     "geoip2-extras": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     },
@@ -111,3 +110,6 @@ GEOIP_PATH = PROJECT_DIR
 # /tests/ if you want to run the demo locally.
 # https://github.com/maxmind/MaxMind-DB/tree/main/test-data
 GEOIP_COUNTRY = "GeoLite2-Country-Test.mmdb"
+
+# Tell the library which Django cache configuration to use.
+GEOIP2_EXTRAS_CACHE_NAME = "geoip2-extras"

--- a/geoip2_extras/middleware.py
+++ b/geoip2_extras/middleware.py
@@ -9,7 +9,7 @@ from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpRequest, HttpResponse
 from geoip2.errors import AddressNotFoundError
 
-from .settings import ADD_RESPONSE_HEADERS, CACHE_TIMEOUT
+from .settings import ADD_RESPONSE_HEADERS, CACHE_NAME, CACHE_TIMEOUT
 
 logger = logging.getLogger(__name__)
 
@@ -78,8 +78,8 @@ class GeoIP2Middleware:
     def __init_cache__(self) -> None:
         """Initialise cache, raise MiddlewareNotUsed on error."""
         try:
-            self.cache = caches["geoip2-extras"]
-            logging.info("GeoIP2 - successfully initialised local cache")
+            self.cache = caches[CACHE_NAME]
+            logging.info("GeoIP2 - successfully initialised cache")
         except InvalidCacheBackendError as ex:
             raise MiddlewareNotUsed(f"GeoIP2 - cache configuration error: {ex}") from ex
 

--- a/geoip2_extras/settings.py
+++ b/geoip2_extras/settings.py
@@ -1,6 +1,9 @@
 # package settings - read from django.conf.settings with defaults.
 from django.conf import settings
 
+# Controls which Django cache configuration to use, falling back to the default.
+CACHE_NAME = getattr(settings, "GEOIP2_EXTRAS_CACHE_NAME", "default")
+
 # time to cache IP <> address data - default to 1hr
 CACHE_TIMEOUT = int(getattr(settings, "GEOIP2_EXTRAS_CACHE_TIMEOUT", 3600))
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -34,5 +34,7 @@ GEOIP_PATH = PROJECT_DIR
 # https://github.com/maxmind/MaxMind-DB/tree/main/test-data
 GEOIP_COUNTRY = "GeoLite2-Country-Test.mmdb"
 
+GEOIP2_EXTRAS_CACHE_NAME = "geoip2-extras"
+
 if not DEBUG:
     raise Exception("This settings file can only be used with DEBUG=True")

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,13 +1,13 @@
 from unittest import mock
 
 import pytest
-from django.conf import settings
 from django.contrib.gis.geoip2 import GeoIP2Exception
 from django.core.cache import caches
 from django.http import HttpResponse
 from django.test import RequestFactory
 from geoip2.errors import AddressNotFoundError
 
+from geoip2_extras import settings
 from geoip2_extras.middleware import (
     UNKNOWN_COUNTRY,
     GeoIP2Middleware,

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from django.conf import settings
 from django.contrib.gis.geoip2 import GeoIP2Exception
 from django.core.cache import caches
 from django.http import HttpResponse
@@ -114,7 +115,7 @@ class TestGeoIP2Middleware:
         middleware = GeoIP2Middleware(lambda r: HttpResponse())
         mock_get.return_value = None
         mock_city_or_country.side_effect = GeoIP2Exception()
-        assert middleware.geo_data("1.2.3.4") == None
+        assert middleware.geo_data("1.2.3.4") is None
 
     @pytest.mark.parametrize("add_headers", [True, False])
     @mock.patch.object(GeoIP2Middleware, "geo_data")
@@ -135,7 +136,7 @@ class TestGeoIP2Middleware:
             assert "x-geoip2-country-code" not in response
 
     def test_cache_set(self):
-        caches["geoip2-extras"].clear()
+        caches[settings.CACHE_NAME].clear()
         middleware = GeoIP2Middleware(lambda r: HttpResponse())
         assert middleware.cache_get("1.2.3.4") is None
         middleware.cache_set("1.2.3.4", {})

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = fmt, lint, mypy, checks, py{3.8,3.9,3.10,3.11}-django{32,40,41,main}
+envlist = fmt, lint, mypy, checks, py{3.8,3.9,3.10,3.11}-django{32,40,41}
 
 [testenv]
 deps =
@@ -11,7 +11,6 @@ deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
-    djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =
     pytest --cov=geoip2_extras --verbose tests


### PR DESCRIPTION
Previously this library forced users into configuring a custom cache configuration at `CACHES["geoip2-extras"]` which is detrimental to proper caching setup as you may wish to re-use an existing configuration such that you can take advantage of connection pooling for instance.

This PR makes a documented breaking change such that the library can be told which cache configuration to use.

Fixes #16.